### PR TITLE
parmetis_interface: use the Fortran API entry point

### DIFF
--- a/src/mod_geometry.f90
+++ b/src/mod_geometry.f90
@@ -688,7 +688,7 @@ module geometry_mod
     real(C_float), allocatable, dimension(:)      :: tpwgts,ubvec  
 
     integer                                       :: i,j
-    integer(C_int64_t)                            :: comm
+    integer(C_int)                                :: comm
 
     if (unstrM%nproc.ge.2) then
        if (unstrM%fsexist) then
@@ -791,7 +791,7 @@ module geometry_mod
     real(C_float), allocatable, dimension(:)      :: tpwgts,ubvec  
 
     integer                                       :: i,j,nct
-    integer(c_int64_t)                            :: comm
+    integer(c_int)                                :: comm
 
    
     if (unstrM%nproc.ge.2) then

--- a/src/parmetis_interface.f90
+++ b/src/parmetis_interface.f90
@@ -178,7 +178,8 @@ module parmetis_interface
              opts,edgecut,part,comm) bind(C,name="parmetis_v3_partkway")
    use, intrinsic                             :: ISO_C_BINDING
    implicit none 
-   integer(C_int64_t)                         :: wgtflag,numflag,ncon,comm,&
+   integer(C_INT)                             :: comm
+   integer(C_int64_t)                         :: wgtflag,numflag,ncon,&
                                                 nparts,edgecut
    integer(C_int64_t), dimension(*)           :: vtxdist,xadj,adjncy,vwgt
    type(C_PTR), value                         :: adjwgt

--- a/src/parmetis_interface.f90
+++ b/src/parmetis_interface.f90
@@ -97,10 +97,14 @@ module parmetis_interface
  !end interface
 
 
+  ! This is a bit of a hack, but it is necessary to invoke the Fortran
+  ! API entry point for ParMETIS so that MPI handles are converted
+  ! properly.  Hence, use the C symbol name parmetis_v3_partmeshkway
+  ! (not the C ParMETIS API entry point ParMETIS_V3_PartMeshKway).
  interface
    integer(C_INT) function ParMETIS_V3_PartMeshKway(elmdist,eptr,eind,&
          elmwgt,wgtflag,numflag,ncon,ncommonnodes,nparts,tpwgts,ubvec,&
-         opts,edgecut,part,comm) bind(C,name="ParMETIS_V3_PartMeshKway")
+         opts,edgecut,part,comm) bind(C,name="parmetis_v3_partmeshkway")
    use, intrinsic                            :: ISO_C_BINDING
    implicit none 
    integer(C_INT)                            :: wgtflag,numflag,ncon,comm,&
@@ -166,10 +170,12 @@ module parmetis_interface
  !end interface
 
 
+ ! Similar to above, be sure to use the Fortran API entry point for
+ ! ParMETIS, not the C API entry point.
  interface
    integer(C_int64_t) function ParMETIS_V3_PartKway(vtxdist,xadj,adjncy,&
                   vwgt,adjwgt,wgtflag,numflag,ncon,nparts,tpwgts,ubvec,&
-             opts,edgecut,part,comm) bind(C,name="ParMETIS_V3_PartKway")
+             opts,edgecut,part,comm) bind(C,name="parmetis_v3_partkway")
    use, intrinsic                             :: ISO_C_BINDING
    implicit none 
    integer(C_int64_t)                         :: wgtflag,numflag,ncon,comm,&


### PR DESCRIPTION
Make sure to use the Fortran API entry points for ParMETIS, not the C
API entry points.  This ensures that MPI handles are properly
converted from Fortran to C.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

Fixes #3 